### PR TITLE
Fix invalid cpr values

### DIFF
--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -1548,7 +1548,7 @@ static void csi_dsr(struct tsm_vte *vte)
 	} else if (vte->csi_argv[0] == 6) {
 		x = tsm_screen_get_cursor_x(vte->con);
 		y = tsm_screen_get_cursor_y(vte->con);
-		len = snprintf(buf, sizeof(buf), "\e[%u;%uR", x, y);
+		len = snprintf(buf, sizeof(buf), "\e[%u;%uR", y + 1, x + 1);
 		if (len >= sizeof(buf))
 			vte_write(vte, "\e[0;0R", 6);
 		else


### PR DESCRIPTION
- First of all, the values were swapped; the row should come *before* the column.
- In addition, libtsm was sending zero-indexed row and column values, while they are supposed to be 1-indexed.