### PR TITLE
Fix wrong background color of new cells after resize

### DIFF
--- a/src/tsm/libtsm-int.h
+++ b/src/tsm/libtsm-int.h
@@ -114,6 +114,11 @@ struct tsm_screen {
 	/* default attributes for new cells */
 	struct tsm_screen_attr def_attr;
 
+	/* save default attributes of main screen here when we switch to alt screen
+	 * on resize of the alt screen we need to init the new cells of the main
+	 * screen with these attributes and not the ones of the alt screen */
+	struct tsm_screen_attr def_attr_main;
+
 	/* ageing */
 	tsm_age_t age_cnt;		/* current age counter */
 	unsigned int age_reset : 1;	/* age-overflow flag */

--- a/test/test_screen.c
+++ b/test/test_screen.c
@@ -133,10 +133,72 @@ START_TEST(test_screen_null)
 }
 END_TEST
 
+START_TEST(test_screen_resize_alt_colors)
+{
+	struct tsm_screen *screen;
+	struct line *line;
+	int r, y, x;
+	struct tsm_screen_attr *attr;
+	struct tsm_screen_attr new_attr;
+
+	r = tsm_screen_new(&screen, NULL, NULL);
+	ck_assert_int_eq(r, 0);
+
+	/* start with an initial 2x2 screen */
+	r = tsm_screen_resize(screen, 2, 2);
+	ck_assert_int_eq(r, 0);
+
+	/* switch to alternate screen */
+	tsm_screen_set_flags(screen, TSM_SCREEN_ALTERNATE);
+
+	/* change background color to red */
+	bzero(&new_attr, sizeof(new_attr));
+	new_attr.br = 255;
+	new_attr.bg = 0;
+	new_attr.bb = 0;
+
+	tsm_screen_set_def_attr(screen, &new_attr);
+	tsm_screen_erase_screen(screen, false);
+
+	/* now all cells should be red */
+	for (y = 0; y < screen->size_y; y++) {
+		line = screen->lines[y];
+		for (x = 0; x < screen->size_x; x++) {
+			attr = &line->cells[x].attr;
+			ck_assert_int_eq(attr->br, 255);
+			ck_assert_int_eq(attr->bg, 0);
+			ck_assert_int_eq(attr->bb, 0);
+		}
+	}
+
+	/* enlarge to 4x4 while on alternate screen */
+	r = tsm_screen_resize(screen, 4, 4);
+	ck_assert_int_eq(r, 0);
+
+	/* leave alternate screen */
+	tsm_screen_reset_flags(screen, TSM_SCREEN_ALTERNATE);
+
+	/* now all cells should be black (including the new ones) */
+	for (y = 0; y < screen->size_y; y++) {
+		line = screen->lines[y];
+		for (x = 0; x < screen->size_x; x++) {
+			attr = &line->cells[x].attr;
+			ck_assert_int_eq(attr->br, 0);
+			ck_assert_int_eq(attr->bg, 0);
+			ck_assert_int_eq(attr->bb, 0);
+		}
+	}
+
+	tsm_screen_unref(screen);
+	screen = NULL;
+}
+END_TEST
+
 
 TEST_DEFINE_CASE(misc)
 	TEST(test_screen_init)
 	TEST(test_screen_null)
+	TEST(test_screen_resize_alt_colors)
 TEST_END_CASE
 
 TEST_DEFINE(


### PR DESCRIPTION
If you enlarge the terminal without this fix while the alt screen is active
(e.g. vim or mc is running) and return to the main screen the newly created
cells on the main screen have the wrong background color.