### PR TITLE
Make code sent by backspace key configurable

### DIFF
--- a/src/tsm/libtsm.h
+++ b/src/tsm/libtsm.h
@@ -409,6 +409,19 @@ void tsm_vte_get_def_attr(struct tsm_vte *vte, struct tsm_screen_attr *out);
 void tsm_vte_reset(struct tsm_vte *vte);
 void tsm_vte_hard_reset(struct tsm_vte *vte);
 void tsm_vte_input(struct tsm_vte *vte, const char *u8, size_t len);
+
+/**
+ * @brief Set backspace key to send either backspace or delete.
+ *
+ * Some terminals send ASCII backspace (010, 8, 0x08), some send ASCII delete
+ * (0177, 127, 0x7f).
+ *
+ * The default for vte is to send ASCII backspace.
+ *
+ * @param vte The vte object to set on
+ * @param enable Send ASCII delete if \c true, send ASCII backspace if \c false.
+ */
+void tsm_vte_set_backspace_sends_delete(struct tsm_vte *vte, bool enable);
 bool tsm_vte_handle_keyboard(struct tsm_vte *vte, uint32_t keysym,
 			     uint32_t ascii, unsigned int mods,
 			     uint32_t unicode);

--- a/src/tsm/libtsm.sym
+++ b/src/tsm/libtsm.sym
@@ -118,5 +118,10 @@ LIBTSM_4 {
 global:
 	tsm_screen_draw;
 
-    tsm_vte_set_custom_palette;
+	tsm_vte_set_custom_palette;
 } LIBTSM_3;
+
+LIBTSM_4_1 {
+global:
+	tsm_vte_set_backspace_sends_delete;
+} LIBTSM_4;

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -103,4 +103,20 @@ static inline int test_run_suite(Suite *s)
 		return test_run_suite(_suite); \
 	}
 
+#ifndef ck_assert_mem_eq
+#include <string.h>
+#define ck_assert_mem_eq(_x, _y, _len) \
+	ck_assert(memcmp((_x), (_y), (_len)) == 0)
+#define ck_assert_mem_ne(_x, _y, _len) \
+	ck_assert(memcmp((_x), (_y), (_len)) != 0)
+#define ck_assert_mem_lt(_x, _y, _len) \
+	ck_assert(memcmp((_x), (_y), (_len)) < 0)
+#define ck_assert_mem_le(_x, _y, _len) \
+	ck_assert(memcmp((_x), (_y), (_len)) <= 0)
+#define ck_assert_mem_gt(_x, _y, _len) \
+	ck_assert(memcmp((_x), (_y), (_len)) > 0)
+#define ck_assert_mem_ge(_x, _y, _len) \
+	ck_assert(memcmp((_x), (_y), (_len)) >= 0)
+#endif
+
 #endif /* TEST_COMMON_H */


### PR DESCRIPTION
Keep the default code as ASCII backspace, but allow setting the code to
ASCII delete. This is the code used by the Linux console and most modern
terminal emulators by default.

Fixes #22.