### PR TITLE
Add mouse tracking

### DIFF
--- a/src/tsm/libtsm.h
+++ b/src/tsm/libtsm.h
@@ -340,12 +340,38 @@ enum tsm_vte_color {
 	TSM_COLOR_NUM
 };
 
-/* mouse tracking */
-#define TSM_VTE_MOUSE_MODE_X10      9
-#define TSM_VTE_MOUSE_EVENT_BTN  1002
-#define TSM_VTE_MOUSE_EVENT_ANY  1003
-#define TSM_VTE_MOUSE_MODE_SGR   1006
-#define TSM_VTE_MOUSE_MODE_PIXEL 1016
+/**
+ * Mouse Tracking
+ *
+ * Reference:
+ *
+ * https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking
+ *
+ * The application running in the terminal can request a mouse tracking mode
+ * and it can configure the event type (send position on click only or on click
+ * and on mouse movement). The terminal will then send the position
+ * of the mouse cursor as requested by the application.
+ *
+ * Since libtsm doesn't know anything about the UI or the mouse this can only
+ * work if the terminal emulator built on top of libtsm cooperates.
+ *
+ * To implement mouse tracking a terminal emulator must first set a mouse
+ * callback with tsm_vte_set_mouse_cb. This callback will be called whenever the
+ * mouse mode changes in a way that is relevant to the terminal. It tells the
+ * terminal if it needs to pass mouse events on click, on move, or not at all.
+ *
+ * To pass the mouse events the terminal needs to call tsm_vte_handle_mouse with
+ * all parameters filled appropriately. The function will then take care of
+ * sending the mouse events to the application in the correct encoding and
+ * it will also discard events that are duplicate or unnecessary.
+ */
+
+/* control sequence codes sent be the application */
+#define TSM_VTE_MOUSE_MODE_X10      9 /* legacy mode (only cell mode, only on mouse click and x and y can be 223 max) */
+#define TSM_VTE_MOUSE_EVENT_BTN  1002 /* sends position on mouse click only */
+#define TSM_VTE_MOUSE_EVENT_ANY  1003 /* sends position on mouse click and mouse move */
+#define TSM_VTE_MOUSE_MODE_SGR   1006 /* modern mode that allows unlimited x and y coordinates */
+#define TSM_VTE_MOUSE_MODE_PIXEL 1016 /* sends pixel coordinates instead of cell coordinates */
 
 enum tsm_mouse_track_mode {
 	TSM_MOUSE_TRACK_DISABLE = 0, /* don't track mouse events */
@@ -353,6 +379,19 @@ enum tsm_mouse_track_mode {
 	TSM_MOUSE_TRACK_ANY = TSM_VTE_MOUSE_EVENT_ANY  /* call tsm_vte_handle_mouse for mouse clicks and mouse movement */
 };
 
+/* mouse buttons to be passed to tsm_vte_handle_mouse */
+#define TSM_MOUSE_BUTTON_LEFT       0
+#define TSM_MOUSE_BUTTON_MIDDLE     1
+#define TSM_MOUSE_BUTTON_RIGHT      2
+#define TSM_MOUSE_BUTTON_WHEEL_UP   4
+#define TSM_MOUSE_BUTTON_WHEEL_DOWN 5
+
+/* modifier keys to be passed to tsm_vte_handle_mouse (can be combined with OR) */
+#define TSM_MOUSE_MODIFIER_SHIFT  4
+#define TSM_MOUSE_MODIFIER_META   8
+#define TSM_MOUSE_MODIFIER_CTRL  16
+
+/* events to be passed to tsm_vte_handle_mouse */
 #define TSM_MOUSE_EVENT_PRESSED  1
 #define TSM_MOUSE_EVENT_RELEASED 2
 #define TSM_MOUSE_EVENT_MOVED    4

--- a/src/tsm/libtsm.h
+++ b/src/tsm/libtsm.h
@@ -340,6 +340,23 @@ enum tsm_vte_color {
 	TSM_COLOR_NUM
 };
 
+/* mouse tracking */
+#define TSM_VTE_MOUSE_MODE_X10      9
+#define TSM_VTE_MOUSE_EVENT_BTN  1002
+#define TSM_VTE_MOUSE_EVENT_ANY  1003
+#define TSM_VTE_MOUSE_MODE_SGR   1006
+#define TSM_VTE_MOUSE_MODE_PIXEL 1016
+
+enum tsm_mouse_track_mode {
+	TSM_MOUSE_TRACK_DISABLE = 0, /* don't track mouse events */
+	TSM_MOUSE_TRACK_BTN = TSM_VTE_MOUSE_EVENT_BTN, /* call tsm_vte_handle_mouse only for mouse clicks */
+	TSM_MOUSE_TRACK_ANY = TSM_VTE_MOUSE_EVENT_ANY  /* call tsm_vte_handle_mouse for mouse clicks and mouse movement */
+};
+
+#define TSM_MOUSE_EVENT_PRESSED  1
+#define TSM_MOUSE_EVENT_RELEASED 2
+#define TSM_MOUSE_EVENT_MOVED    4
+
 typedef void (*tsm_vte_write_cb) (struct tsm_vte *vte,
 				  const char *u8,
 				  size_t len,
@@ -350,6 +367,11 @@ typedef void (*tsm_vte_osc_cb) (struct tsm_vte *vte,
 				  size_t len,
 				  void *data);
 
+typedef void (*tsm_vte_mouse_cb) (struct tsm_vte *vte,
+				  enum tsm_mouse_track_mode track_mode,
+				  bool track_pixels,
+				  void *data);
+
 int tsm_vte_new(struct tsm_vte **out, struct tsm_screen *con,
 		tsm_vte_write_cb write_cb, void *data,
 		tsm_log_t log, void *log_data);
@@ -357,6 +379,7 @@ void tsm_vte_ref(struct tsm_vte *vte);
 void tsm_vte_unref(struct tsm_vte *vte);
 
 void tsm_vte_set_osc_cb(struct tsm_vte *vte, tsm_vte_osc_cb osc_cb, void *osc_data);
+void tsm_vte_set_mouse_cb(struct tsm_vte *vte, tsm_vte_mouse_cb mouse_cb, void *mouse_data);
 
 /**
  * @brief Set color palette to one of the predefined palette on the vte object.
@@ -427,6 +450,9 @@ int tsm_vte_set_custom_palette(struct tsm_vte *vte, uint8_t (*palette)[3]);
 void tsm_vte_get_def_attr(struct tsm_vte *vte, struct tsm_screen_attr *out);
 unsigned int tsm_vte_get_flags(struct tsm_vte *vte);
 
+unsigned int tsm_vte_get_mouse_mode(struct tsm_vte *vte);
+unsigned int tsm_vte_get_mouse_event(struct tsm_vte *vte);
+
 void tsm_vte_reset(struct tsm_vte *vte);
 void tsm_vte_hard_reset(struct tsm_vte *vte);
 void tsm_vte_input(struct tsm_vte *vte, const char *u8, size_t len);
@@ -446,6 +472,9 @@ void tsm_vte_set_backspace_sends_delete(struct tsm_vte *vte, bool enable);
 bool tsm_vte_handle_keyboard(struct tsm_vte *vte, uint32_t keysym,
 			     uint32_t ascii, unsigned int mods,
 			     uint32_t unicode);
+bool tsm_vte_handle_mouse(struct tsm_vte *vte, unsigned int cell_x,
+        unsigned int cell_y, unsigned int pixel_x, unsigned int pixel_y,
+        unsigned int button, unsigned int event, unsigned char flags);
 
 /** @} */
 

--- a/src/tsm/libtsm.sym
+++ b/src/tsm/libtsm.sym
@@ -125,4 +125,8 @@ LIBTSM_4_1 {
 global:
 	tsm_vte_set_backspace_sends_delete;
 	tsm_vte_get_flags;
+	tsm_vte_set_mouse_cb;
+	tsm_vte_get_mouse_mode;
+	tsm_vte_get_mouse_event;
+	tsm_vte_handle_mouse;
 } LIBTSM_4;

--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -616,8 +616,6 @@ unsigned int tsm_vte_get_mouse_event(struct tsm_vte *vte)
 	return vte->mouse_event;
 }
 
-unsigned int tsm_vte_get_mouse_event(struct tsm_vte *vte);
-
 /*
  * Write raw byte-stream to pty.
  * When writing data to the client we must make sure that we send the correct
@@ -3093,9 +3091,9 @@ bool tsm_vte_handle_mouse(struct tsm_vte *vte, unsigned int cell_x,
 		cell_x++;
 		cell_y++;
 
-		if (button == 4) {
+		if (button == TSM_MOUSE_BUTTON_WHEEL_UP) {
 			button = 64;
-		} else if (button == 5) {
+		} else if (button == TSM_MOUSE_BUTTON_WHEEL_DOWN) {
 			button = 65;
 		}
 

--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -117,6 +117,26 @@ enum parser_action {
 /* max length of an OSC code */
 #define OSC_MAX_LEN 128
 
+/* terminal flags */
+#define FLAG_CURSOR_KEY_MODE			0x00000001 /* DEC cursor key mode */
+#define FLAG_KEYPAD_APPLICATION_MODE		0x00000002 /* DEC keypad application mode; TODO: toggle on numlock? */
+#define FLAG_LINE_FEED_NEW_LINE_MODE		0x00000004 /* DEC line-feed/new-line mode */
+#define FLAG_8BIT_MODE				0x00000008 /* Disable UTF-8 mode and enable 8bit compatible mode */
+#define FLAG_7BIT_MODE				0x00000010 /* Disable 8bit mode and use 7bit compatible mode */
+#define FLAG_USE_C1				0x00000020 /* Explicitly use 8bit C1 codes; TODO: implement */
+#define FLAG_KEYBOARD_ACTION_MODE		0x00000040 /* Disable keyboard; TODO: implement? */
+#define FLAG_INSERT_REPLACE_MODE		0x00000080 /* Enable insert mode */
+#define FLAG_SEND_RECEIVE_MODE			0x00000100 /* Disable local echo */
+#define FLAG_TEXT_CURSOR_MODE			0x00000200 /* Show cursor */
+#define FLAG_INVERSE_SCREEN_MODE		0x00000400 /* Inverse colors */
+#define FLAG_ORIGIN_MODE			0x00000800 /* Relative origin for cursor */
+#define FLAG_AUTO_WRAP_MODE			0x00001000 /* Auto line wrap mode */
+#define FLAG_AUTO_REPEAT_MODE			0x00002000 /* Auto repeat key press; TODO: implement */
+#define FLAG_NATIONAL_CHARSET_MODE		0x00004000 /* Send keys from nation charsets; TODO: implement */
+#define FLAG_BACKGROUND_COLOR_ERASE_MODE	0x00008000 /* Set background color on erase (bce) */
+#define FLAG_PREPEND_ESCAPE			0x00010000 /* Prepend escape character to next output */
+#define FLAG_TITE_INHIBIT_MODE			0x00020000 /* Prevent switching to alternate screen buffer */
+
 struct vte_saved_state {
 	unsigned int cursor_x;
 	unsigned int cursor_y;
@@ -149,6 +169,13 @@ struct tsm_vte {
 	void *osc_data;
 	unsigned int osc_len;
 	char osc_arg[OSC_MAX_LEN];
+
+	tsm_vte_mouse_cb mouse_cb;
+	void *mouse_data;
+	unsigned int mouse_mode;
+	unsigned int mouse_event;
+	unsigned int mouse_last_col;
+	unsigned int mouse_last_row;
 
 	uint8_t (*custom_palette_storage)[3];
 	uint8_t (*palette)[3];
@@ -426,6 +453,8 @@ int tsm_vte_new(struct tsm_vte **out, struct tsm_screen *con,
 	vte->backspace_sends_delete = false;
 	vte->osc_cb = NULL;
 	vte->osc_data = NULL;
+	vte->mouse_cb = NULL;
+	vte->mouse_data = NULL;
 	vte->custom_palette_storage = NULL;
 	vte->palette = get_palette(vte);
 	vte->def_attr.fccode = TSM_COLOR_FOREGROUND;
@@ -483,6 +512,16 @@ void tsm_vte_set_osc_cb(struct tsm_vte *vte, tsm_vte_osc_cb osc_cb, void *osc_da
 
 	vte->osc_cb = osc_cb;
 	vte->osc_data = osc_data;
+}
+
+SHL_EXPORT
+void tsm_vte_set_mouse_cb(struct tsm_vte *vte, tsm_vte_mouse_cb mouse_cb, void *mouse_data)
+{
+	if (!vte)
+		return;
+
+	vte->mouse_cb = mouse_cb;
+	vte->mouse_data = mouse_data;
 }
 
 static int vte_update_palette(struct tsm_vte *vte)
@@ -556,6 +595,28 @@ unsigned int tsm_vte_get_flags(struct tsm_vte *vte)
 {
 	return vte->flags;
 }
+
+SHL_EXPORT
+unsigned int tsm_vte_get_mouse_mode(struct tsm_vte *vte)
+{
+	if (!vte) {
+		return 0;
+	}
+
+	return vte->mouse_mode;
+}
+
+SHL_EXPORT
+unsigned int tsm_vte_get_mouse_event(struct tsm_vte *vte)
+{
+	if (!vte) {
+		return 0;
+	}
+
+	return vte->mouse_event;
+}
+
+unsigned int tsm_vte_get_mouse_event(struct tsm_vte *vte);
 
 /*
  * Write raw byte-stream to pty.
@@ -721,6 +782,11 @@ void tsm_vte_reset(struct tsm_vte *vte)
 	vte->g1 = &tsm_vte_unicode_upper;
 	vte->g2 = &tsm_vte_unicode_lower;
 	vte->g3 = &tsm_vte_unicode_upper;
+
+	vte->mouse_mode = 0;
+	vte->mouse_event = 0;
+	vte->mouse_last_col = 0;
+	vte->mouse_last_row = 0;
 
 	memcpy(&vte->cattr, &vte->def_attr, sizeof(vte->cattr));
 	to_rgb(vte, &vte->cattr);
@@ -1509,6 +1575,14 @@ static void csi_mode(struct tsm_vte *vte, bool set)
 		case 8: /* DECARM */
 			set_reset_flag(vte, set, TSM_VTE_FLAG_AUTO_REPEAT_MODE);
 			continue;
+		case TSM_VTE_MOUSE_MODE_X10:
+			vte->mouse_mode = set ? vte->csi_argv[i] : 0;
+			vte->mouse_event = TSM_VTE_MOUSE_EVENT_BTN;
+
+			if (vte->mouse_cb) {
+			    vte->mouse_cb(vte, vte->mouse_event, false, vte->mouse_data);
+			}
+			continue;
 		case 12: /* blinking cursor */
 			/* TODO: implement */
 			continue;
@@ -1590,6 +1664,42 @@ static void csi_mode(struct tsm_vte *vte, bool set)
 						       TSM_SCREEN_ALTERNATE);
 				tsm_screen_move_to(vte->con, vte->alt_cursor_x,
 						   vte->alt_cursor_y);
+			}
+			continue;
+		case TSM_VTE_MOUSE_EVENT_BTN:
+		case TSM_VTE_MOUSE_EVENT_ANY:
+			if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_X10) {
+			    vte->mouse_event = TSM_VTE_MOUSE_EVENT_BTN;
+			} else {
+			    vte->mouse_event = set ? vte->csi_argv[i] : 0;
+			}
+
+			if (vte->mouse_cb && vte->mouse_mode) {
+			    vte->mouse_cb(vte, vte->mouse_event, vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL, vte->mouse_data);
+			}
+			continue;
+		case TSM_VTE_MOUSE_MODE_SGR:
+			vte->mouse_mode = set ? vte->csi_argv[i] : 0;
+
+			if (!vte->mouse_cb) {
+			    continue;
+			}
+
+			if (!set || vte->mouse_event) {
+			    vte->mouse_cb(vte, vte->mouse_event, false, vte->mouse_data);
+			    continue;
+			}
+			continue;
+		case TSM_VTE_MOUSE_MODE_PIXEL:
+			vte->mouse_mode = set ? vte->csi_argv[i] : 0;
+
+			if (!vte->mouse_cb) {
+			    continue;
+			}
+
+			if (!set || vte->mouse_event) {
+			    vte->mouse_cb(vte, vte->mouse_event, set, vte->mouse_data);
+			    continue;
 			}
 			continue;
 		default:
@@ -2961,5 +3071,90 @@ bool tsm_vte_handle_keyboard(struct tsm_vte *vte, uint32_t keysym,
 	}
 
 	vte->flags &= ~TSM_VTE_FLAG_PREPEND_ESCAPE;
+	return false;
+}
+
+bool tsm_vte_handle_mouse(struct tsm_vte *vte, unsigned int cell_x,
+		unsigned int cell_y, unsigned int pixel_x, unsigned int pixel_y,
+		unsigned int button, unsigned int event, unsigned char modifiers)
+{
+	char buffer[24];
+	unsigned char reply_flags = 0;
+	bool pressed = event & TSM_MOUSE_EVENT_PRESSED;
+
+	/* drop move event if we don't wait for move events */
+	if ((vte->mouse_mode == TSM_VTE_MOUSE_MODE_X10 || vte->mouse_event != TSM_VTE_MOUSE_EVENT_ANY) && (event & TSM_MOUSE_EVENT_MOVED)) {
+		return false;
+	}
+
+	if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_SGR || vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL) {
+		/* internally we use zero indexing but the xterm spec requires the
+		 * top left cell to have the coordinates 1,1 */
+		cell_x++;
+		cell_y++;
+
+		if (button == 4) {
+			button = 64;
+		} else if (button == 5) {
+			button = 65;
+		}
+
+		reply_flags = button | modifiers;
+	}
+
+	if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_X10) {
+		/* + 0x20 to start in the range of visible characters
+		 * and + 1 to start at 1,1 */
+		cell_x += 0x21;
+		cell_y += 0x21;
+
+		if (cell_x > 0xff) {
+			cell_x = 0xff;
+		}
+
+		if (cell_y > 0xff) {
+			cell_y = 0xff;
+		}
+
+		if (event & TSM_MOUSE_EVENT_RELEASED) {
+			/* translates to released but the information which key is
+			 * released gets lost by design of this encoding scheme */
+			button = 3;
+		}
+
+		reply_flags = (button | modifiers) + 0x20;
+		snprintf((char*) &buffer, sizeof(buffer), "\e[M%c%c%c", reply_flags, cell_x, cell_y);
+
+		vte_write(vte, buffer, strlen(buffer));
+		return true;
+	} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_SGR && vte->mouse_event) {
+		if (event & TSM_MOUSE_EVENT_MOVED) {
+			if (cell_x == vte->mouse_last_col && cell_y == vte->mouse_last_row) {
+				return false;
+			}
+
+			reply_flags = 35;
+			pressed = true;
+
+			vte->mouse_last_col = cell_x;
+			vte->mouse_last_row = cell_y;
+		}
+
+		snprintf((char*) &buffer, sizeof(buffer), "\e[<%d;%d;%d%c", reply_flags, cell_x, cell_y, pressed ? 'M' : 'm');
+
+		vte_write(vte, buffer, strlen(buffer));
+		return true;
+	} else if (vte->mouse_mode == TSM_VTE_MOUSE_MODE_PIXEL && vte->mouse_event) {
+		if (event == TSM_MOUSE_EVENT_MOVED) {
+			reply_flags = 35;
+			pressed = true;
+		}
+
+		snprintf((char*) &buffer, sizeof(buffer), "\e[<%d;%d;%d%c", reply_flags, pixel_x, pixel_y, pressed ? 'M' : 'm');
+
+		vte_write(vte, buffer, strlen(buffer));
+		return true;
+	}
+
 	return false;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,12 @@ libtsm_add_test(test_vte
         check::check
 )
 
+libtsm_add_test(test_vte_mouse
+    LINK_LIBRARIES
+        tsm_test
+        check::check
+)
+
 # This is only a quick sanity check that verifies the
 # valgrind tests work properly.
 libtsm_add_test(test_valgrind

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -56,6 +56,8 @@
 								\
 		tc = tcase_create(#_name);			\
 
+#define CHECKED_FIXTURE(_setup, _teardown) tcase_add_checked_fixture(tc, _setup, _teardown);
+#define FIXTURE(_setup, _teardown) tcase_add_fixture(tc, _setup, _teardown);
 #define TEST(_name) tcase_add_test(tc, _name);
 
 #define TEST_END_CASE						\

--- a/test/test_vte.c
+++ b/test/test_vte.c
@@ -92,6 +92,9 @@ START_TEST(test_vte_null)
 
 	tsm_vte_get_def_attr(NULL, NULL);
 
+    tsm_vte_get_mouse_mode(NULL);
+    tsm_vte_get_mouse_event(NULL);
+
 	tsm_vte_reset(NULL);
 	tsm_vte_hard_reset(NULL);
 	tsm_vte_input(NULL, "", 0);

--- a/test/test_vte.c
+++ b/test/test_vte.c
@@ -92,8 +92,8 @@ START_TEST(test_vte_null)
 
 	tsm_vte_get_def_attr(NULL, NULL);
 
-    tsm_vte_get_mouse_mode(NULL);
-    tsm_vte_get_mouse_event(NULL);
+	tsm_vte_get_mouse_mode(NULL);
+	tsm_vte_get_mouse_event(NULL);
 
 	tsm_vte_reset(NULL);
 	tsm_vte_hard_reset(NULL);

--- a/test/test_vte_mouse.c
+++ b/test/test_vte_mouse.c
@@ -1,0 +1,343 @@
+/*
+ * TSM - VTE State Machine Tests
+ *
+ * Copyright (c) 2022 Andreas Heck <aheck@gmx.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include "libtsm-int.h"
+#include "libtsm.h"
+#include "test_common.h"
+
+char write_buffer[512];
+
+bool mouse_cb_called = false;
+unsigned int mouse_track_mode = 0;
+bool mouse_track_pixels = false;
+
+static void write_cb(struct tsm_vte *vte, const char *u8, size_t len, void *data)
+{
+	ck_assert_ptr_ne(vte, NULL);
+	ck_assert_ptr_ne(u8, NULL);
+
+	memcpy(&write_buffer, u8, len);
+	write_buffer[len] = '\0';
+}
+
+static void mouse_cb(struct tsm_vte *vte, enum tsm_mouse_track_mode track_mode, bool track_pixels, void *data)
+{
+	mouse_cb_called = true;
+	mouse_track_mode = track_mode;
+	mouse_track_pixels = track_pixels;
+}
+
+struct tsm_screen *screen;
+struct tsm_vte *vte;
+
+void setup()
+{
+	int r;
+
+	r = tsm_screen_new(&screen, NULL, NULL);
+	ck_assert_int_eq(r, 0);
+
+	r = tsm_vte_new(&vte, screen, write_cb, NULL, NULL, NULL);
+	ck_assert_int_eq(r, 0);
+
+	tsm_vte_set_mouse_cb(vte, mouse_cb, NULL);
+
+	mouse_cb_called = false;
+	mouse_track_mode = 0;
+	mouse_track_pixels = false;
+
+	bzero(&write_buffer, sizeof(write_buffer));
+}
+
+void teardown()
+{
+	tsm_vte_unref(vte);
+	vte = NULL;
+
+	tsm_screen_unref(screen);
+	screen = NULL;
+}
+
+START_TEST(test_mouse_cb_x10)
+{
+	char *msg;
+
+	/* Set X10 Mode */
+	msg = "\e[?9h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	ck_assert(mouse_cb_called);
+	ck_assert_int_eq(mouse_track_mode, TSM_MOUSE_TRACK_BTN);
+	ck_assert(!mouse_track_pixels);
+}
+END_TEST
+
+START_TEST(test_mouse_x10)
+{
+	char *msg;
+	char *expected;
+	int r;
+
+	/* Set X10 Mode */
+	msg = "\e[?9h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	/* left click on left upper cell (0, 0) should be translated to (1, 1) in output */
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 0, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[M !!";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* right click on (0, 0) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 2, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[M\"!!";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* middle click on (0, 0) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 1, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[M!!!";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* left click out of range (299, 279) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 299, 279, 0, 0, 0, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[M \xff\xff";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+}
+END_TEST
+
+START_TEST(test_mouse_cb_sgr)
+{
+	char *msg;
+
+	/* Set SGR Mode */
+	msg = "\e[?1006h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	/* mouse_cb should not be called if event type is not set */
+	ck_assert(!mouse_cb_called);
+
+	/* reset for next test */
+	mouse_cb_called = false;
+	mouse_track_mode = 0;
+	mouse_track_pixels = false;
+
+	/* Set Button Events */
+	bzero(&write_buffer, sizeof(write_buffer));
+	msg = "\e[?1002h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	ck_assert(mouse_cb_called);
+	ck_assert_int_eq(mouse_track_mode, TSM_MOUSE_TRACK_BTN);
+	ck_assert(!mouse_track_pixels);
+}
+END_TEST
+
+START_TEST(test_mouse_sgr)
+{
+	char *expected;
+	char *msg;
+	int r;
+
+	/* Set SGR Mode and only notify for mouse button clicks */
+	msg = "\e[?1006h\e[?1002h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	/* left click on left upper cell (0, 0) should be translated to (1, 1) in output */
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 0, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<0;1;1M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* button release event for (1, 1) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 0, TSM_MOUSE_EVENT_RELEASED, 0);
+	expected = "\e[<0;1;1m";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* button 1 (middle mouse button) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 1, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<1;1;1M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* button 2 (right mouse button) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 2, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<2;1;1M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* button 4 (mouse wheel up scroll) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 4, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<64;1;1M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* button 5 (mouse wheel down scroll) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 5, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<65;1;1M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* check for (50, 120) */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 49, 119, 0, 0, 0, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<0;50;120M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+}
+END_TEST
+
+START_TEST(test_mouse_sgr_cell_change)
+{
+	char *msg;
+	char *expected;
+	int r;
+
+	/* Set SGR Mode and only notify for mouse button clicks */
+	msg = "\e[?1006h\e[?1003h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	/* move over (0, 0) */
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 0, TSM_MOUSE_EVENT_MOVED, 0);
+	expected = "\e[<35;1;1M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* repeated reportings of the same cell should be ignored */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 0, 0, 0, TSM_MOUSE_EVENT_MOVED, 0);
+	ck_assert_int_eq(write_buffer[0], 0);
+
+	/* different cells must be reported */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 1, 1, 0, 0, 0, TSM_MOUSE_EVENT_MOVED, 0);
+	expected = "\e[<35;2;2M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	/* a click must be reported in all cases */
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 1, 1, 0, 0, 0, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<0;2;2M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+}
+END_TEST
+
+START_TEST(test_mouse_cb_pixels)
+	char *msg;
+
+	/* Set Pixel Mode */
+	msg = "\e[?1016h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	/* mouse_cb should not be called if event type is not set */
+	ck_assert(!mouse_cb_called);
+
+	/* reset for next test */
+	mouse_cb_called = false;
+	mouse_track_mode = 0;
+	mouse_track_pixels = false;
+
+	/* Set Button Events */
+	bzero(&write_buffer, sizeof(write_buffer));
+	msg = "\e[?1003h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	ck_assert(mouse_cb_called);
+	ck_assert_int_eq(mouse_track_mode, TSM_MOUSE_TRACK_ANY);
+	ck_assert(mouse_track_pixels);
+END_TEST
+
+START_TEST(test_mouse_pixels)
+{
+	char *msg;
+	char *expected;
+	int r;
+
+	/* Set SGR Mode and only notify for mouse button clicks */
+	msg = "\e[?1016h\e[?1003h";
+	tsm_vte_input(vte, msg, strlen(msg));
+
+	tsm_vte_handle_mouse(vte, 0, 0, 236, 120, 0, TSM_MOUSE_EVENT_MOVED, 0);
+	expected = "\e[<35;236;120M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 236, 120, 0, TSM_MOUSE_EVENT_PRESSED, 0);
+	expected = "\e[<0;236;120M";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+
+	bzero(&write_buffer, sizeof(write_buffer));
+	tsm_vte_handle_mouse(vte, 0, 0, 236, 120, 0, TSM_MOUSE_EVENT_RELEASED, 0);
+	expected = "\e[<0;236;120m";
+	r = memcmp(&write_buffer, expected, strlen(expected));
+	ck_assert_int_eq(r, 0);
+}
+END_TEST
+
+TEST_DEFINE_CASE(tests_x10)
+	CHECKED_FIXTURE(setup, teardown)
+	TEST(test_mouse_cb_x10)
+	TEST(test_mouse_x10)
+TEST_END_CASE
+
+TEST_DEFINE_CASE(tests_sgr)
+	CHECKED_FIXTURE(setup, teardown)
+	TEST(test_mouse_cb_sgr)
+	TEST(test_mouse_sgr)
+	TEST(test_mouse_sgr_cell_change)
+TEST_END_CASE
+
+TEST_DEFINE_CASE(tests_sgr_pixels)
+	CHECKED_FIXTURE(setup, teardown)
+	TEST(test_mouse_cb_pixels)
+	TEST(test_mouse_pixels)
+TEST_END_CASE
+
+// clang-format off
+TEST_DEFINE(
+	TEST_SUITE(vte_mouse,
+		TEST_CASE(tests_x10),
+		TEST_CASE(tests_sgr),
+		TEST_CASE(tests_sgr_pixels),
+		TEST_END
+	)
+)
+// clang-format on

--- a/test/test_vte_mouse.c
+++ b/test/test_vte_mouse.c
@@ -23,10 +23,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include <stdio.h>
-#include "libtsm-int.h"
-#include "libtsm.h"
 #include "test_common.h"
+#include "libtsm.h"
+#include "libtsm-int.h"
 
 char write_buffer[512];
 
@@ -259,6 +258,7 @@ START_TEST(test_mouse_sgr_cell_change)
 END_TEST
 
 START_TEST(test_mouse_cb_pixels)
+{
 	char *msg;
 
 	/* Set Pixel Mode */
@@ -281,6 +281,7 @@ START_TEST(test_mouse_cb_pixels)
 	ck_assert(mouse_cb_called);
 	ck_assert_int_eq(mouse_track_mode, TSM_MOUSE_TRACK_ANY);
 	ck_assert(mouse_track_pixels);
+}
 END_TEST
 
 START_TEST(test_mouse_pixels)


### PR DESCRIPTION
This patch implements the legacy X10 mode and the newer SGR and SGR Pixel modes. It omits the EXT and URXVT modes because their use is discouraged anyway (https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking). With the first one the encoding is ambigious and the second one is no improvement over SGR mode. Not implementing them keeps the complexity down and if people actually use them (which they shouldn't) we could still add them in the future.

X10 can only encode a limited number of rows and cols (224) which can be a problem with modern ultra-wide displays. But AFAIK people used it in the past and it is good to have it for compatibility. SGR is the new encoding that fixes X10 and SGR Pixel mode was introduced by xterm in 2020 and allows to track pixels instead of rows and cols and might see more use in the future.

In addition to the unit tests (which I derived from values gathered from xterm) I tested it in midnight commander and clicking as well as scrolling with the mouse wheel worked as expected.