### PR TITLE
Fix a memleak in tsm_screen_unref and one in a test

### DIFF
--- a/src/tsm/tsm-screen.c
+++ b/src/tsm/tsm-screen.c
@@ -538,10 +538,12 @@ void tsm_screen_unref(struct tsm_screen *con)
 		line_free(con->main_lines[i]);
 		line_free(con->alt_lines[i]);
 	}
+
 	free(con->main_lines);
 	free(con->alt_lines);
 	free(con->tab_ruler);
 	tsm_symbol_table_unref(con->sym_table);
+	tsm_screen_clear_sb(con);
 	free(con);
 }
 

--- a/test/test_vte.c
+++ b/test/test_vte.c
@@ -206,6 +206,12 @@ START_TEST(test_vte_backspace_key)
 	ck_assert(r);
 	r = tsm_vte_handle_keyboard(vte, XKB_KEY_BackSpace, 0177, 0, 0177);
 	ck_assert(r);
+
+	tsm_vte_unref(vte);
+	vte = NULL;
+
+	tsm_screen_unref(screen);
+	screen = NULL;
 }
 END_TEST
 


### PR DESCRIPTION
I found both problems when running tests with build type ASan. With this fix ASan finds nothing to complain about anymore.