### PR TITLE
Add unhandled ECMA-48 CSI sequences `\E[nE` and `\E[nF`

### DIFF
--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -1791,6 +1791,14 @@ static void do_csi(struct tsm_vte *vte, uint32_t data)
 		x = tsm_screen_get_cursor_x(vte->con);
 		tsm_screen_move_to(vte->con, x, num - 1);
 		break;
+	case 'E': /* CNL */
+		/* Move cursor down the indicated # of rows, to column 1 */
+		num = vte->csi_argv[0];
+		if (num <= 0)
+			num = 1;
+		y = tsm_screen_get_cursor_y(vte->con);
+		tsm_screen_move_to(vte->con, 0, y + num);
+		break;
 	case 'e': /* VPR */
 		/* Vertical Line Position Relative */
 		num = vte->csi_argv[0];
@@ -1799,6 +1807,14 @@ static void do_csi(struct tsm_vte *vte, uint32_t data)
 		x = tsm_screen_get_cursor_x(vte->con);
 		y = tsm_screen_get_cursor_y(vte->con);
 		tsm_screen_move_to(vte->con, x, y + num);
+		break;
+	case 'F': /* CPL */
+		/* Move cursor up the indicated # of rows, to column 1 */
+		num = vte->csi_argv[0];
+		if (num <= 0)
+			num = 1;
+		y = tsm_screen_get_cursor_y(vte->con);
+		tsm_screen_move_to(vte->con, 0, y - num);
 		break;
 	case 'H': /* CUP */
 	case 'f': /* HVP */

--- a/src/tsm/tsm-vte.c
+++ b/src/tsm/tsm-vte.c
@@ -1796,8 +1796,8 @@ static void do_csi(struct tsm_vte *vte, uint32_t data)
 		num = vte->csi_argv[0];
 		if (num <= 0)
 			num = 1;
-		y = tsm_screen_get_cursor_y(vte->con);
-		tsm_screen_move_to(vte->con, 0, y + num);
+		tsm_screen_move_down(vte->con, num, false);
+		tsm_screen_move_line_home(vte->con);
 		break;
 	case 'e': /* VPR */
 		/* Vertical Line Position Relative */
@@ -1813,8 +1813,8 @@ static void do_csi(struct tsm_vte *vte, uint32_t data)
 		num = vte->csi_argv[0];
 		if (num <= 0)
 			num = 1;
-		y = tsm_screen_get_cursor_y(vte->con);
-		tsm_screen_move_to(vte->con, 0, y - num);
+		tsm_screen_move_up(vte->con, num, false);
+		tsm_screen_move_line_home(vte->con);
 		break;
 	case 'H': /* CUP */
 	case 'f': /* HVP */

--- a/test/test_vte.c
+++ b/test/test_vte.c
@@ -28,6 +28,7 @@
 #include "test_common.h"
 
 #include <xkbcommon/xkbcommon-keysyms.h>
+#include <stdio.h>
 
 static void log_cb(void *data, const char *file, int line, const char *func, const char *subs,
 				   unsigned int sev, const char *format, va_list args)
@@ -286,6 +287,8 @@ START_TEST(test_vte_csi_cursor_up_down)
 	struct tsm_screen *screen;
 	struct tsm_vte *vte;
 	int r;
+	int h, w;
+	char csi_cmd[64];
 
 	r = tsm_screen_new(&screen, log_cb, NULL);
 	ck_assert_int_eq(r, 0);
@@ -303,6 +306,19 @@ START_TEST(test_vte_csi_cursor_up_down)
 	// cursor move down, first col
 	tsm_vte_input(vte, "\033[1E", 4);
 	assert_tsm_screen_cursor_pos(screen, 0, 1);
+
+	h = tsm_screen_get_height(screen);
+	w = tsm_screen_get_width(screen);
+
+	// move cursor up out of screen, should at first line
+	sprintf(csi_cmd, "\033[%dF", h + 10);
+	tsm_vte_input(vte, csi_cmd, strlen(csi_cmd));
+	assert_tsm_screen_cursor_pos(screen, 0, 0);
+
+	// move cursor down out of screen, should at last line
+	sprintf(csi_cmd, "\033[%dE", h + 10);
+	tsm_vte_input(vte, csi_cmd, strlen(csi_cmd));
+	assert_tsm_screen_cursor_pos(screen, 0, h - 1);
 
 	tsm_vte_unref(vte);
 	vte = NULL;


### PR DESCRIPTION
Add unhandled ECMA-48 CSI sequences `\E[nE` and `\E[nF`
  E   CNL       Move cursor down the indicated # of rows, to column 1
  F   CPL       Move cursor up the indicated # of rows, to column 1

Fix Aetf/kmscon#78